### PR TITLE
catch: cover interior pointers in hipHostGetDevicePointer

### DIFF
--- a/catch/unit/memory/hipHostGetDevicePointer.cc
+++ b/catch/unit/memory/hipHostGetDevicePointer.cc
@@ -84,6 +84,85 @@ HIP_TEST_CASE(Unit_hipHostGetDevicePointer_UseCase) {
   HIP_CHECK(hipHostFree(hPtr));
 }
 
+// hipHostGetDevicePointer maps an address, not an allocation: a host pointer
+// inside a mapped allocation must yield a device pointer carrying the same
+// offset from the device base. Every other case in this file allocates
+// sizeof(int) and queries offset 0, which cannot tell a correct runtime apart
+// from one that returns the allocation base for any pointer inside it.
+HIP_TEST_CASE(Unit_hipHostGetDevicePointer_InteriorPointer) {
+  if (!DeviceAttributesSupport(0, hipDeviceAttributeCanMapHostMemory)) {
+    HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);
+  }
+
+  constexpr size_t kSize = 1u << 16;
+  constexpr size_t kOffsets[] = {sizeof(int), 4096, kSize - sizeof(int)};
+  constexpr int kSentinel = 0x5eed;
+
+  auto kernel = set<int>;
+
+  // Queries base + offset and checks both the pointer arithmetic against the
+  // device base and that a write through the returned pointer lands at that
+  // offset of the host allocation.
+  auto checkInterior = [&](char* base, void* devBase, size_t offset) {
+    int* dPtr{nullptr};
+    HIP_CHECK(hipHostGetDevicePointer(reinterpret_cast<void**>(&dPtr), base + offset, 0));
+    REQUIRE(dPtr != nullptr);
+    REQUIRE(reinterpret_cast<char*>(dPtr) - reinterpret_cast<char*>(devBase) ==
+            static_cast<ptrdiff_t>(offset));
+
+    const int before = *reinterpret_cast<int*>(base);
+
+    kernel<<<1, 1>>>(dPtr, kSentinel);
+    HIP_CHECK(hipGetLastError());
+    HIP_CHECK(hipDeviceSynchronize());
+
+    REQUIRE(*reinterpret_cast<int*>(base + offset) == kSentinel);
+    // A runtime that dropped the offset would have written to the base instead.
+    REQUIRE(*reinterpret_cast<int*>(base) == before);
+  };
+
+  SECTION("hipHostMalloc") {
+    char* base{nullptr};
+    HIP_CHECK(hipHostMalloc(reinterpret_cast<void**>(&base), kSize, hipHostMallocMapped));
+    for (size_t i = 0; i < kSize; i++) base[i] = 0;
+
+    void* devBase{nullptr};
+    HIP_CHECK(hipHostGetDevicePointer(&devBase, base, 0));
+
+    for (size_t offset : kOffsets) {
+      checkInterior(base, devBase, offset);
+    }
+
+    HIP_CHECK(hipHostFree(base));
+  }
+
+  SECTION("hipHostRegister") {
+    char* base = reinterpret_cast<char*>(malloc(kSize));
+    REQUIRE(base != nullptr);
+    for (size_t i = 0; i < kSize; i++) base[i] = 0;
+    HIP_CHECK(hipHostRegister(base, kSize, hipHostRegisterMapped));
+
+    // Query an interior pointer before the base, which is what an application
+    // laying several fields out in one allocation does.
+    int* dInterior{nullptr};
+    HIP_CHECK(hipHostGetDevicePointer(reinterpret_cast<void**>(&dInterior),
+                                      base + kOffsets[0], 0));
+    REQUIRE(dInterior != nullptr);
+
+    void* devBase{nullptr};
+    HIP_CHECK(hipHostGetDevicePointer(&devBase, base, 0));
+    REQUIRE(reinterpret_cast<char*>(dInterior) - reinterpret_cast<char*>(devBase) ==
+            static_cast<ptrdiff_t>(kOffsets[0]));
+
+    for (size_t offset : kOffsets) {
+      checkInterior(base, devBase, offset);
+    }
+
+    HIP_CHECK(hipHostUnregister(base));
+    free(base);
+  }
+}
+
 HIP_TEST_CASE(Unit_hipHostGetDevicePointer_Capture) {
   if (!DeviceAttributesSupport(0, hipDeviceAttributeCanMapHostMemory)) {
     HIP_SKIP_TEST(HipTest::SkipReason::kHostPinnedMemoryUnsupported);


### PR DESCRIPTION
Every existing case in `catch/unit/memory/hipHostGetDevicePointer.cc` allocates `sizeof(int)` and queries offset 0:

```
HIP_CHECK(hipHostMalloc(&hPtr, sizeof(int)));
HIP_CHECK(hipHostGetDevicePointer(reinterpret_cast<void**>(&dPtr), hPtr, 0));
```

so a runtime that returns the allocation base for any pointer inside a mapped allocation passes all of them. `hipHostGetDevicePointer` maps an address rather than an allocation, and the AMD implementation adds the offset back (`hipamd/src/hip_memory.cpp`, `getMemoryObject(hostPointer, offset)` then `virtualAddress() + offset`), so the offset behaviour is part of the contract and currently untested.

This adds `Unit_hipHostGetDevicePointer_InteriorPointer`, which queries several interior offsets of a 64 KiB allocation for both `hipHostMalloc(hipHostMallocMapped)` and `hipHostRegister(hipHostRegisterMapped)` and checks two things per offset: the returned pointer keeps the same offset from the device base, and a write through it lands at that offset rather than at the allocation base. The `hipHostRegister` section queries an interior pointer before the base, which is the order an application laying several fields out in one allocation uses, and which exercises lazily created device backing.

Found because a HIP implementation dropped the offset and this file did not catch it. An application doing one `hipHostMalloc` per bucket and one `hipHostGetDevicePointer` per field read the first field's bytes for every later field, with no error returned.

Draft: the test is a port of a reproducer validated against that implementation, but I have not yet run it in this suite against a ROCm device. Marking ready once that is done.
